### PR TITLE
LIBITD-2069. Updated Solr to mitigate CVE-2021-44228

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM solr:8.1.1 as builder
+FROM solr:8.11.0@sha256:f9f6eed52e186f8e8ca0d4b7eae1acdbb94ad382c4d84c8220d78e3020d746c6 as builder
 # Switch to root user
 USER root
 # Install xmlstarlet
@@ -41,7 +41,7 @@ RUN /opt/solr/bin/solr start && sleep 3 && \
         --data-binary @/tmp/data.csv -H 'Content-type:application/csv'&& \
     /opt/solr/bin/solr stop
 # For deceasing the size of the image
-FROM solr:8.1.1-slim
+FROM solr:8.11.0-slim@sha256:530547ad87f3fb02ed9fbbdbf40c0bfbfd8a0b472d8fea5920a87ec65aaacaef
 ENV SOLR_HOME=/apps/solr/data
 USER root
 RUN mkdir -p /apps/solr/ && \


### PR DESCRIPTION
Using tagged hash version, to ensure that mitigation is picked up.

https://issues.umd.edu/browse/LIBITD-2069